### PR TITLE
LOC-28 DatabaseManager 어댑터 패턴 도입(Postgres/MySQL/SQLite)

### DIFF
--- a/app/api/databases.py
+++ b/app/api/databases.py
@@ -6,6 +6,7 @@
 from fastapi import APIRouter, Depends, HTTPException, status, Query, Request
 from sqlalchemy.orm import Session
 from typing import List, Optional
+from datetime import datetime
 import logging
 
 from app.database import get_db, Database, get_all_databases, get_database_by_id, create_database_record
@@ -329,6 +330,7 @@ async def test_database_connection(
 
         # 실제 연결 테스트 수행 (현재 password_encrypted는 평문 비밀번호 사용 가정)
         success, elapsed_ms, error_msg = db_manager.test_connection(
+            db_type=database.db_type,
             host=database.host,
             port=database.port,
             dbname=database.database_name,
@@ -409,4 +411,105 @@ async def reload_databases_config():
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="설정 리로드 중 오류가 발생했습니다."
+        )
+
+
+# =============================================================================
+# 연결 풀 관리 API
+# =============================================================================
+
+@router.post("/{database_id}/init-pool", response_model=dict)
+async def init_database_pool(
+    database_id: str,
+    db: Session = Depends(get_db)
+):
+    """데이터베이스 연결 풀 초기화"""
+    try:
+        database = get_database_by_id(db, database_id)
+        if not database:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="데이터베이스를 찾을 수 없습니다."
+            )
+
+        # 연결 풀 생성
+        pool = db_manager.get_or_create_pool(
+            database_id=database_id,
+            db_type=database.db_type,
+            host=database.host,
+            port=database.port,
+            dbname=database.database_name,
+            user=database.username,
+            password=database.password_encrypted,
+            sslmode=database.ssl_mode,
+            minconn=1,
+            maxconn=5,
+        )
+
+        return {
+            "database_id": database_id,
+            "status": "success",
+            "message": f"{database.db_type} 연결 풀이 초기화되었습니다.",
+            "pool_type": type(pool).__name__
+        }
+        
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"연결 풀 초기화 오류 (DB {database_id}): {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="연결 풀 초기화 중 오류가 발생했습니다."
+        )
+
+
+@router.delete("/{database_id}/close-pool", response_model=dict)
+async def close_database_pool(
+    database_id: str,
+    db: Session = Depends(get_db)
+):
+    """데이터베이스 연결 풀 종료"""
+    try:
+        database = get_database_by_id(db, database_id)
+        if not database:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="데이터베이스를 찾을 수 없습니다."
+            )
+
+        # 연결 풀 종료
+        db_manager.close_pool(database_id)
+
+        return {
+            "database_id": database_id,
+            "status": "success",
+            "message": f"{database.db_type} 연결 풀이 종료되었습니다."
+        }
+        
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"연결 풀 종료 오류 (DB {database_id}): {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="연결 풀 종료 중 오류가 발생했습니다."
+        )
+
+
+@router.get("/pool-status", response_model=dict)
+async def get_pool_status():
+    """모든 연결 풀 상태 조회"""
+    try:
+        status_summary = db_manager.get_status_summary()
+        return {
+            "status": "success",
+            "summary": status_summary,
+            "timestamp": datetime.utcnow().isoformat()
+        }
+        
+    except Exception as e:
+        logger.error(f"풀 상태 조회 오류: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="풀 상태 조회 중 오류가 발생했습니다."
         )

--- a/app/core/database_adapters.py
+++ b/app/core/database_adapters.py
@@ -1,0 +1,463 @@
+"""
+데이터베이스 어댑터 패턴 구현
+- 다중 DB 타입 지원 (PostgreSQL, MySQL, SQLite)
+- 통일된 인터페이스로 연결/풀/테스트 기능 제공
+- 각 DB별 최적화된 구현체 제공
+
+주의:
+- 변수명은 기존 코드와 충돌하지 않도록 새로운 범위에서만 정의
+- 외부 의존성 추가 금지 (requirements.txt 내 패키지만 사용)
+- Windows/Unix 환경 모두 동작
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+from abc import ABC, abstractmethod
+from datetime import datetime
+from typing import Any, Dict, Optional, Tuple, Union
+
+import psycopg2
+from psycopg2.pool import SimpleConnectionPool
+from app.config import get_config_manager
+
+try:
+    import pymysql
+    MYSQL_AVAILABLE = True
+except ImportError:
+    MYSQL_AVAILABLE = False
+
+
+class DatabaseAdapter(ABC):
+    """데이터베이스 어댑터 인터페이스
+    
+    모든 DB 타입에 대해 통일된 인터페이스를 제공합니다.
+    """
+    
+    def __init__(self, database_id: str) -> None:
+        self.database_id = database_id
+    
+    @abstractmethod
+    def create_pool(
+        self,
+        *,
+        host: str,
+        port: int,
+        dbname: str,
+        user: str,
+        password: Optional[str],
+        sslmode: Optional[str],
+        minconn: int = 1,
+        maxconn: int = 5,
+    ) -> Any:
+        """연결 풀을 생성합니다."""
+        pass
+    
+    @abstractmethod
+    def get_connection(self) -> Any:
+        """연결 풀에서 연결을 가져옵니다."""
+        pass
+    
+    @abstractmethod
+    def put_connection(self, conn: Any) -> None:
+        """연결을 연결 풀에 반환합니다."""
+        pass
+    
+    @abstractmethod
+    def close_pool(self) -> None:
+        """연결 풀을 종료합니다."""
+        pass
+    
+    @abstractmethod
+    def test_connection(
+        self,
+        *,
+        host: str,
+        port: int,
+        dbname: str,
+        user: str,
+        password: Optional[str],
+        sslmode: Optional[str],
+        timeout_seconds: int = 5,
+    ) -> Tuple[bool, float, Optional[str]]:
+        """DB 연결 테스트를 수행합니다.
+        
+        Returns:
+            Tuple[bool, float, Optional[str]]: (성공여부, 응답시간(ms), 오류메시지)
+        """
+        pass
+
+
+class PostgresAdapter(DatabaseAdapter):
+    """PostgreSQL 어댑터 (psycopg2 기반)"""
+    
+    def __init__(self, database_id: str) -> None:
+        super().__init__(database_id)
+        self._pool: Optional[SimpleConnectionPool] = None
+    
+    def _make_conn_params(
+        self, 
+        *, 
+        host: str, 
+        port: int, 
+        dbname: str, 
+        user: str, 
+        password: Optional[str], 
+        sslmode: Optional[str]
+    ) -> Dict[str, Any]:
+        """psycopg2 연결 파라미터 구성"""
+        params: Dict[str, Any] = {
+            "host": host,
+            "port": int(port) if port is not None else 5432,
+            "dbname": dbname,
+            "user": user,
+            "connect_timeout": 5,
+        }
+        if password:
+            params["password"] = password
+        # sslmode가 지정되지 않았으면 설정의 기본값을 사용
+        params["sslmode"] = sslmode or self._get_default_ssl_mode()
+        return params
+    
+    def _get_default_ssl_mode(self) -> str:
+        """설정 파일의 기본 SSL 모드 반환"""
+        try:
+            cm = get_config_manager()
+            app_settings = cm.load_app_settings() or {}
+            sec = (app_settings.get('security') or {})
+            mode = str(sec.get('db_ssl_mode_default') or '').strip().lower()
+            if mode in {"disable", "prefer", "require", "verify-ca", "verify-full"}:
+                return mode
+        except Exception:
+            pass
+        return "require"
+    
+    def create_pool(
+        self,
+        *,
+        host: str,
+        port: int,
+        dbname: str,
+        user: str,
+        password: Optional[str],
+        sslmode: Optional[str],
+        minconn: int = 1,
+        maxconn: int = 5,
+    ) -> SimpleConnectionPool:
+        """PostgreSQL 연결 풀 생성"""
+        if self._pool is not None:
+            return self._pool
+        
+        params = self._make_conn_params(
+            host=host, port=port, dbname=dbname, 
+            user=user, password=password, sslmode=sslmode
+        )
+        self._pool = SimpleConnectionPool(minconn, maxconn, **params)
+        return self._pool
+    
+    def get_connection(self) -> psycopg2.extensions.connection:
+        """연결 풀에서 연결 가져오기"""
+        if self._pool is None:
+            raise RuntimeError("연결 풀이 존재하지 않습니다. 먼저 create_pool을 호출하세요.")
+        return self._pool.getconn()
+    
+    def put_connection(self, conn: psycopg2.extensions.connection) -> None:
+        """연결을 연결 풀에 반환"""
+        if self._pool is None:
+            # 풀이 이미 제거된 경우 안전하게 종료만 시도
+            try:
+                conn.close()
+            finally:
+                return
+        self._pool.putconn(conn)
+    
+    def close_pool(self) -> None:
+        """연결 풀 종료"""
+        if self._pool is not None:
+            self._pool.closeall()
+            self._pool = None
+    
+    def test_connection(
+        self,
+        *,
+        host: str,
+        port: int,
+        dbname: str,
+        user: str,
+        password: Optional[str],
+        sslmode: Optional[str],
+        timeout_seconds: int = 5,
+    ) -> Tuple[bool, float, Optional[str]]:
+        """PostgreSQL 연결 테스트"""
+        start = time.perf_counter()
+        try:
+            params = self._make_conn_params(
+                host=host, port=port, dbname=dbname, 
+                user=user, password=password, sslmode=sslmode
+            )
+            params["connect_timeout"] = timeout_seconds
+            conn = psycopg2.connect(**params)
+            try:
+                cur = conn.cursor()
+                cur.execute("SELECT 1")
+                cur.fetchone()
+                cur.close()
+            finally:
+                conn.close()
+            elapsed_ms = (time.perf_counter() - start) * 1000.0
+            return True, elapsed_ms, None
+        except Exception as e:
+            elapsed_ms = (time.perf_counter() - start) * 1000.0
+            return False, elapsed_ms, str(e)
+
+
+class MySQLAdapter(DatabaseAdapter):
+    """MySQL 어댑터 (PyMySQL 기반)"""
+    
+    def __init__(self, database_id: str) -> None:
+        super().__init__(database_id)
+        self._pool_config: Optional[Dict[str, Any]] = None
+        self._connections: Dict[int, Any] = {}  # 간단한 연결 풀 구현
+        self._max_connections = 5
+        self._min_connections = 1
+        
+        if not MYSQL_AVAILABLE:
+            raise RuntimeError("PyMySQL이 설치되지 않았습니다. pip install PyMySQL을 실행하세요.")
+    
+    def _make_conn_params(
+        self, 
+        *, 
+        host: str, 
+        port: int, 
+        dbname: str, 
+        user: str, 
+        password: Optional[str], 
+        sslmode: Optional[str]
+    ) -> Dict[str, Any]:
+        """PyMySQL 연결 파라미터 구성"""
+        params: Dict[str, Any] = {
+            "host": host,
+            "port": int(port) if port is not None else 3306,
+            "database": dbname,  # MySQL은 database 파라미터 사용
+            "user": user,
+            "connect_timeout": 5,
+            "charset": "utf8mb4",
+            "autocommit": True,
+        }
+        if password:
+            params["password"] = password
+        
+        # SSL 설정 (sslmode를 MySQL SSL 설정으로 변환)
+        if sslmode and sslmode != "disable":
+            params["ssl"] = {"ssl_disabled": False}
+            if sslmode in ["verify-ca", "verify-full"]:
+                params["ssl"]["check_hostname"] = True
+        else:
+            params["ssl_disabled"] = True
+        
+        return params
+    
+    def create_pool(
+        self,
+        *,
+        host: str,
+        port: int,
+        dbname: str,
+        user: str,
+        password: Optional[str],
+        sslmode: Optional[str],
+        minconn: int = 1,
+        maxconn: int = 5,
+    ) -> Dict[str, Any]:
+        """MySQL 연결 풀 설정 저장 (실제 풀은 간단하게 구현)"""
+        self._pool_config = self._make_conn_params(
+            host=host, port=port, dbname=dbname, 
+            user=user, password=password, sslmode=sslmode
+        )
+        self._min_connections = minconn
+        self._max_connections = maxconn
+        return self._pool_config
+    
+    def get_connection(self) -> Any:
+        """연결 풀에서 연결 가져오기"""
+        if self._pool_config is None:
+            raise RuntimeError("연결 풀이 존재하지 않습니다. 먼저 create_pool을 호출하세요.")
+        
+        # 사용 가능한 연결이 있는지 확인
+        for conn_id, conn in list(self._connections.items()):
+            if conn and conn.open:
+                del self._connections[conn_id]
+                return conn
+        
+        # 새 연결 생성 (최대 연결 수 확인)
+        if len(self._connections) < self._max_connections:
+            conn = pymysql.connect(**self._pool_config)
+            return conn
+        
+        raise RuntimeError("최대 연결 수에 도달했습니다.")
+    
+    def put_connection(self, conn: Any) -> None:
+        """연결을 연결 풀에 반환"""
+        if conn and conn.open and len(self._connections) < self._max_connections:
+            conn_id = id(conn)
+            self._connections[conn_id] = conn
+        else:
+            # 연결 종료
+            try:
+                if conn:
+                    conn.close()
+            except Exception:
+                pass
+    
+    def close_pool(self) -> None:
+        """연결 풀 종료"""
+        for conn in self._connections.values():
+            try:
+                if conn and conn.open:
+                    conn.close()
+            except Exception:
+                pass
+        self._connections.clear()
+        self._pool_config = None
+    
+    def test_connection(
+        self,
+        *,
+        host: str,
+        port: int,
+        dbname: str,
+        user: str,
+        password: Optional[str],
+        sslmode: Optional[str],
+        timeout_seconds: int = 5,
+    ) -> Tuple[bool, float, Optional[str]]:
+        """MySQL 연결 테스트"""
+        start = time.perf_counter()
+        try:
+            params = self._make_conn_params(
+                host=host, port=port, dbname=dbname, 
+                user=user, password=password, sslmode=sslmode
+            )
+            params["connect_timeout"] = timeout_seconds
+            conn = pymysql.connect(**params)
+            try:
+                cursor = conn.cursor()
+                cursor.execute("SELECT 1")
+                cursor.fetchone()
+                cursor.close()
+            finally:
+                conn.close()
+            elapsed_ms = (time.perf_counter() - start) * 1000.0
+            return True, elapsed_ms, None
+        except Exception as e:
+            elapsed_ms = (time.perf_counter() - start) * 1000.0
+            return False, elapsed_ms, str(e)
+
+
+class SQLiteAdapter(DatabaseAdapter):
+    """SQLite 어댑터 (sqlite3 기반)
+    
+    SQLite는 파일 기반이므로 연결 풀이 불필요합니다.
+    각 요청마다 새로운 연결을 생성하고 즉시 종료합니다.
+    """
+    
+    def __init__(self, database_id: str) -> None:
+        super().__init__(database_id)
+        self._db_path: Optional[str] = None
+    
+    def create_pool(
+        self,
+        *,
+        host: str,
+        port: int,
+        dbname: str,
+        user: str,
+        password: Optional[str],
+        sslmode: Optional[str],
+        minconn: int = 1,
+        maxconn: int = 5,
+    ) -> str:
+        """SQLite 데이터베이스 경로 설정
+        
+        SQLite는 연결 풀이 불필요하므로 파일 경로만 저장합니다.
+        host가 'localhost'이거나 비어있으면 dbname을 파일 경로로 사용합니다.
+        """
+        # SQLite는 파일 기반이므로 host/port는 무시하고 dbname을 파일 경로로 사용
+        if not dbname:
+            raise ValueError("SQLite는 dbname(파일 경로)이 필요합니다.")
+        
+        # 절대 경로가 아니면 상대 경로로 처리
+        if not dbname.startswith(('/')) and not (len(dbname) > 1 and dbname[1] == ':'):
+            # Windows/Unix 절대 경로가 아닌 경우
+            self._db_path = dbname
+        else:
+            self._db_path = dbname
+        
+        return self._db_path
+    
+    def get_connection(self) -> sqlite3.Connection:
+        """SQLite 연결 생성"""
+        if self._db_path is None:
+            raise RuntimeError("데이터베이스 경로가 설정되지 않았습니다. 먼저 create_pool을 호출하세요.")
+        
+        conn = sqlite3.connect(self._db_path, timeout=5.0)
+        conn.row_factory = sqlite3.Row  # 딕셔너리 형태로 결과 반환
+        return conn
+    
+    def put_connection(self, conn: sqlite3.Connection) -> None:
+        """SQLite 연결 종료 (풀에 반환하지 않고 즉시 종료)"""
+        try:
+            if conn:
+                conn.close()
+        except Exception:
+            pass
+    
+    def close_pool(self) -> None:
+        """SQLite는 풀이 없으므로 경로만 초기화"""
+        self._db_path = None
+    
+    def test_connection(
+        self,
+        *,
+        host: str,
+        port: int,
+        dbname: str,
+        user: str,
+        password: Optional[str],
+        sslmode: Optional[str],
+        timeout_seconds: int = 5,
+    ) -> Tuple[bool, float, Optional[str]]:
+        """SQLite 연결 테스트"""
+        start = time.perf_counter()
+        try:
+            if not dbname:
+                raise ValueError("SQLite는 dbname(파일 경로)이 필요합니다.")
+            
+            conn = sqlite3.connect(dbname, timeout=float(timeout_seconds))
+            try:
+                cursor = conn.cursor()
+                cursor.execute("SELECT 1")
+                cursor.fetchone()
+                cursor.close()
+            finally:
+                conn.close()
+            elapsed_ms = (time.perf_counter() - start) * 1000.0
+            return True, elapsed_ms, None
+        except Exception as e:
+            elapsed_ms = (time.perf_counter() - start) * 1000.0
+            return False, elapsed_ms, str(e)
+
+
+def create_adapter(db_type: str, database_id: str) -> DatabaseAdapter:
+    """DB 타입에 따른 어댑터 팩토리 함수"""
+    db_type = db_type.lower().strip()
+    
+    if db_type == "postgresql":
+        return PostgresAdapter(database_id)
+    elif db_type == "mysql":
+        return MySQLAdapter(database_id)
+    elif db_type == "sqlite":
+        return SQLiteAdapter(database_id)
+    else:
+        raise ValueError(f"지원하지 않는 데이터베이스 타입입니다: {db_type}")

--- a/app/core/database_manager.py
+++ b/app/core/database_manager.py
@@ -1,6 +1,7 @@
 """
-다중 데이터베이스 연결/풀/상태 관리 매니저
-- psycopg2 SimpleConnectionPool 기반 연결 풀 관리
+다중 데이터베이스 연결/풀/상태 관리 매니저 (어댑터 패턴 기반)
+- PostgreSQL, MySQL, SQLite 지원
+- 어댑터 패턴으로 DB별 최적화된 연결 관리
 - 연결 테스트 기능 제공
 - 상태 요약 및 리소스 정리 지원
 
@@ -14,62 +15,31 @@ from __future__ import annotations
 
 import time
 from datetime import datetime
-from typing import Dict, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple
 
-import psycopg2
-from psycopg2.pool import SimpleConnectionPool
-from app.config import get_config_manager
+from app.core.database_adapters import DatabaseAdapter, create_adapter
 
 # 내부 모델에 직접 의존하지 않도록 최소한의 인터페이스만 사용
 # app.api 계층에서 SQLAlchemy 모델(Database)을 전달받아 필요한 필드만 활용
 
 
 class DatabaseManager:
-    """다중 데이터베이스 연결/풀/상태 관리 클래스"""
+    """다중 데이터베이스 연결/풀/상태 관리 클래스 (어댑터 패턴 기반)"""
 
     def __init__(self) -> None:
-        # 데이터베이스별로 연결 풀을 관리 (key: database.id)
-        self._pools: Dict[str, SimpleConnectionPool] = {}
+        # 데이터베이스별로 어댑터를 관리 (key: database.id)
+        self._adapters: Dict[str, DatabaseAdapter] = {}
 
     # -----------------------------
     # 내부 유틸리티
     # -----------------------------
-    def _make_conn_params(self, *, host: str, port: int, dbname: str, user: str, password: Optional[str], sslmode: Optional[str]) -> Dict[str, object]:
-        """psycopg2 연결 파라미터 구성
-        - connect_timeout 기본 5초
-        - sslmode는 Database.ssl_mode 값을 그대로 전달 (없으면 settings의 security.db_ssl_mode_default 사용, 최종 폴백은 require)
-        """
-        params: Dict[str, object] = {
-            "host": host,
-            "port": int(port) if port is not None else 5432,
-            "dbname": dbname,
-            "user": user,
-            "connect_timeout": 5,
-        }
-        if password:
-            params["password"] = password
-        # sslmode가 지정되지 않았으면 설정의 기본값을 사용 (보안/레거시 환경 모두 대응)
-        params["sslmode"] = sslmode or self._get_default_ssl_mode()
-        return params
-
-    def _get_default_ssl_mode(self) -> str:
-        """설정 파일(settings.yaml)의 security.db_ssl_mode_default를 읽어 기본 sslmode 반환
-        - 허용 값: disable | prefer | require | verify-ca | verify-full
-        - 잘못된 값이거나 오류 시 'require'로 폴백
-        """
-        try:
-            cm = get_config_manager()
-            app_settings = cm.load_app_settings() or {}
-            sec = (app_settings.get('security') or {})
-            mode = str(sec.get('db_ssl_mode_default') or '').strip().lower()
-            if mode in {"disable", "prefer", "require", "verify-ca", "verify-full"}:
-                return mode
-        except Exception:
-            pass
-        return "require"
-
-    def _pool_key(self, database_id: str) -> str:
-        return str(database_id)
+    def _get_adapter(self, database_id: str, db_type: str) -> DatabaseAdapter:
+        """데이터베이스 어댑터 가져오기 (없으면 생성)"""
+        adapter = self._adapters.get(database_id)
+        if adapter is None:
+            adapter = create_adapter(db_type, database_id)
+            self._adapters[database_id] = adapter
+        return adapter
 
     # -----------------------------
     # 공개 API: 연결 풀 관리
@@ -78,6 +48,7 @@ class DatabaseManager:
         self,
         *,
         database_id: str,
+        db_type: str,
         host: str,
         port: int,
         dbname: str,
@@ -86,52 +57,49 @@ class DatabaseManager:
         sslmode: Optional[str],
         minconn: int = 1,
         maxconn: int = 5,
-    ) -> SimpleConnectionPool:
+    ) -> Any:
         """해당 데이터베이스에 대한 연결 풀을 반환 (없으면 생성)
-        - 연결 풀은 SimpleConnectionPool(minconn, maxconn, **params) 사용
+        - 어댑터 패턴으로 DB 타입별 최적화된 풀 생성
         """
-        key = self._pool_key(database_id)
-        pool = self._pools.get(key)
-        if pool is None:
-            params = self._make_conn_params(host=host, port=port, dbname=dbname, user=user, password=password, sslmode=sslmode)
-            pool = SimpleConnectionPool(minconn, maxconn, **params)
-            self._pools[key] = pool
-        return pool
+        adapter = self._get_adapter(database_id, db_type)
+        return adapter.create_pool(
+            host=host, port=port, dbname=dbname, 
+            user=user, password=password, sslmode=sslmode,
+            minconn=minconn, maxconn=maxconn
+        )
 
-    def get_connection(self, database_id: str) -> psycopg2.extensions.connection:
+    def get_connection(self, database_id: str, db_type: str) -> Any:
         """연결 풀에서 연결을 하나 가져옵니다."""
-        key = self._pool_key(database_id)
-        pool = self._pools.get(key)
-        if pool is None:
+        adapter = self._adapters.get(database_id)
+        if adapter is None:
             raise RuntimeError("연결 풀이 존재하지 않습니다. 먼저 get_or_create_pool을 호출하세요.")
-        return pool.getconn()
+        return adapter.get_connection()
 
-    def put_connection(self, database_id: str, conn: psycopg2.extensions.connection) -> None:
+    def put_connection(self, database_id: str, conn: Any) -> None:
         """연결을 연결 풀에 반환합니다."""
-        key = self._pool_key(database_id)
-        pool = self._pools.get(key)
-        if pool is None:
-            # 풀이 이미 제거된 경우 안전하게 종료만 시도
+        adapter = self._adapters.get(database_id)
+        if adapter is None:
+            # 어댑터가 이미 제거된 경우 안전하게 종료만 시도
             try:
-                conn.close()
+                if hasattr(conn, 'close'):
+                    conn.close()
             finally:
                 return
-        pool.putconn(conn)
+        adapter.put_connection(conn)
 
     def close_pool(self, database_id: str) -> None:
         """특정 데이터베이스의 연결 풀을 종료합니다."""
-        key = self._pool_key(database_id)
-        pool = self._pools.pop(key, None)
-        if pool is not None:
-            pool.closeall()
+        adapter = self._adapters.pop(database_id, None)
+        if adapter is not None:
+            adapter.close_pool()
 
     def close_all(self) -> None:
         """모든 연결 풀을 종료합니다."""
-        for key, pool in list(self._pools.items()):
+        for database_id, adapter in list(self._adapters.items()):
             try:
-                pool.closeall()
+                adapter.close_pool()
             finally:
-                self._pools.pop(key, None)
+                self._adapters.pop(database_id, None)
 
     # -----------------------------
     # 공개 API: 연결 테스트/상태
@@ -139,6 +107,7 @@ class DatabaseManager:
     def test_connection(
         self,
         *,
+        db_type: str,
         host: str,
         port: int,
         dbname: str,
@@ -147,34 +116,25 @@ class DatabaseManager:
         sslmode: Optional[str],
         timeout_seconds: int = 5,
     ) -> Tuple[bool, float, Optional[str]]:
-        """DB 연결 테스트 수행
+        """
+        DB 연결 테스트 수행 (어댑터 기반)
         반환: (성공여부, 응답시간(ms), 오류메시지)
         """
-        start = time.perf_counter()
-        try:
-            params = self._make_conn_params(host=host, port=port, dbname=dbname, user=user, password=password, sslmode=sslmode)
-            # 개별 테스트는 풀을 거치지 않고 직접 연결하여 지연/에러 측정
-            params["connect_timeout"] = timeout_seconds
-            conn = psycopg2.connect(**params)
-            try:
-                cur = conn.cursor()
-                cur.execute("SELECT 1")
-                cur.fetchone()
-                cur.close()
-            finally:
-                conn.close()
-            elapsed_ms = (time.perf_counter() - start) * 1000.0
-            return True, elapsed_ms, None
-        except Exception as e:
-            elapsed_ms = (time.perf_counter() - start) * 1000.0
-            return False, elapsed_ms, str(e)
+        # 임시 어댑터를 생성하여 테스트 수행 (풀에 저장하지 않음)
+        temp_adapter = create_adapter(db_type, "temp_test")
+        return temp_adapter.test_connection(
+            host=host, port=port, dbname=dbname,
+            user=user, password=password, sslmode=sslmode,
+            timeout_seconds=timeout_seconds
+        )
 
     def get_status_summary(self) -> Dict[str, int]:
-        """간단한 상태 요약 반환
-        - 관리 중인 풀 개수 등 메타 정보 제공
+        """
+        간단한 상태 요약 반환
+        - 관리 중인 어댑터 개수 등 메타 정보 제공
         """
         return {
-            "managed_pools": len(self._pools),
+            "managed_adapters": len(self._adapters),
         }
 
 

--- a/docs/Design-Rationale.md
+++ b/docs/Design-Rationale.md
@@ -107,3 +107,9 @@
 - `Database` 모델에 `db_type` 컬럼을 추가하여 PostgreSQL, MySQL, SQLite 등 다중 데이터베이스 타입을 지원하고, 기본값 `postgresql`로 기존 레코드 호환성을 보장했습니다.
 - Alembic 마이그레이션(`20250918_add_db_type_column.py`)으로 안전한 스키마 변경을 수행하고, `ix_databases_db_type`와 `ix_databases_db_type_environment` 인덱스를 추가해 조회 성능을 최적화했습니다.
 - API 입력 검증에 `db_type` 필드를 반영하여 생성/수정 시 지원하지 않는 DB 타입 입력을 차단하고, 필터링(`?db_type=postgresql`) 및 정렬(`?sort=db_type`) 기능을 제공해 운영 편의성을 향상시켰습니다.
+
+## 8.2 DatabaseManager 어댑터화 (다중 DB 연결 관리)
+
+- `DatabaseAdapter` 추상 인터페이스를 정의하고 PostgreSQL(psycopg2), MySQL(PyMySQL), SQLite(sqlite3) 각각에 최적화된 어댑터를 구현하여 DB별 연결 풀 전략을 차별화했습니다.
+- 기존 `DatabaseManager`를 어댑터 패턴 기반으로 리팩토링하여 `db_type` 파라미터로 동적 어댑터 선택이 가능하도록 하고, 연결 풀 관리 API(`init-pool`, `close-pool`, `pool-status`)를 추가했습니다.
+- PostgreSQL은 SimpleConnectionPool, MySQL은 커스텀 풀, SQLite는 즉시 연결 방식으로 각 DB의 특성에 맞는 최적화된 연결 관리를 구현하여 확장성과 성능을 동시에 확보했습니다.

--- a/docs/Issues-Guidelines.md
+++ b/docs/Issues-Guidelines.md
@@ -482,11 +482,11 @@
 
 작업 내용:
 
-- [ ] DatabaseAdapter 인터페이스 정의(create_pool/getconn/putconn/close_all/test_connection)
-- [ ] PostgresAdapter 구현(기존 psycopg2 기반 이식)
-- [ ] MySQLAdapter 구현(PyMySQL 또는 mysqlclient 기반, 풀 전략 결정)
-- [ ] SQLiteAdapter 구현(sqlite3, 풀 불필요 처리)
-- [ ] /api/databases/\* 엔드포인트가 어댑터 기반으로 동작하도록 변경
+- [x] DatabaseAdapter 인터페이스 정의(create_pool/getconn/putconn/close_all/test_connection)
+- [x] PostgresAdapter 구현(기존 psycopg2 기반 이식)
+- [x] MySQLAdapter 구현(PyMySQL 기반, 풀 전략 결정)
+- [x] SQLiteAdapter 구현(sqlite3, 풀 불필요 처리)
+- [x] /api/databases/* 엔드포인트가 어댑터 기반으로 동작하도록 변경
 ```
 
 #### 8.3 BackupEngine 백업 전략 어댑터

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 fastapi==0.115.0
 uvicorn==0.32.0
 psycopg2-binary==2.9.10
+pymysql==1.1.1
 apscheduler==3.10.4
 cryptography==43.0.1
 pydantic==2.9.2


### PR DESCRIPTION
작업 내용:

- [x] DatabaseAdapter 인터페이스 정의(create_pool/getconn/putconn/close_all/test_connection)
- [x] PostgresAdapter 구현(기존 psycopg2 기반 이식)
- [x] MySQLAdapter 구현(PyMySQL 기반, 풀 전략 결정)
- [x] SQLiteAdapter 구현(sqlite3, 풀 불필요 처리)
- [x] /api/databases/* 엔드포인트가 어댑터 기반으로 동작하도록 변경

fixes #24